### PR TITLE
fix initialization issues: do not rely on empty `new()` semantics 

### DIFF
--- a/TyPython/src/CPython.jl
+++ b/TyPython/src/CPython.jl
@@ -22,6 +22,7 @@ mutable struct Configuration
     function Configuration()
         this = new()
         this.IS_DEAD = false
+        this.INIT_INDICATOR = C_NULL  # 1.7
         return this
     end
 end


### PR DESCRIPTION
julia 1.7 `new` does not zero initialize to `Ptr{Cvoid}`.
