### PR TITLE
use Pkg.activate in the fast path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Note that JNumPy will install julia in `JNUMPY_HOME` for you, if there is no Jul
         end
     end
 
+    # the following code is optional,
+    # but makes Python code loading much faster since the second time.
+    precompile(init, ())
+
     end
     ```
 

--- a/TyPython/Project.toml
+++ b/TyPython/Project.toml
@@ -9,9 +9,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]

--- a/TyPython/src/Utils.jl
+++ b/TyPython/src/Utils.jl
@@ -1,7 +1,6 @@
 module Utils
 import IOCapture
-import TOML
-import Pkg
+
 function capture_out(f)
     capture = IOCapture.capture() do
         f()
@@ -15,22 +14,6 @@ end
         push!(block.args, :(f($i, args...)))
     end
     block
-end
-
-function add_deps(toml_path::String)
-    proj_toml = TOML.parsefile(toml_path)
-    deps = get(proj_toml, "deps", Dict())
-    current_deps = Pkg.project().dependencies
-    current_deps = Dict(k=>string(v) for (k,v) in pairs(current_deps))
-    new_deps = merge(current_deps, deps)
-    current_deps_path = Pkg.project().path
-    open(current_deps_path, "w") do io
-        data = TOML.parsefile(current_deps_path)
-        data["deps"] = new_deps
-        TOML.print(io, data)
-    end
-    Pkg.resolve()
-    Pkg.instantiate()
 end
 
 end

--- a/demo/basic/src/basic.jl
+++ b/demo/basic/src/basic.jl
@@ -18,4 +18,6 @@ function init()
     end
 end
 
+precompile(init, ())
+
 end

--- a/demo/fft/src/fast_fft.jl
+++ b/demo/fft/src/fast_fft.jl
@@ -27,4 +27,6 @@ function init()
     end
 end
 
+precompile(init, ())
+
 end # end of module

--- a/demo/kmeans/src/fast_kmeans.jl
+++ b/demo/kmeans/src/fast_kmeans.jl
@@ -16,4 +16,6 @@ function init()
     end
 end
 
+precompile(init, ())
+
 end

--- a/jnumpy/InitTools.jl
+++ b/jnumpy/InitTools.jl
@@ -1,7 +1,8 @@
 module InitTools
-
 import Pkg
 import UUIDs
+
+@nospecialize
 
 function check_if_typython_installed(typython_dir::AbstractString)
     VERSION >= v"1.9" && error("Support for Julia 1.9 is coming soon.")
@@ -23,8 +24,6 @@ function _develop_typython(typython_dir::AbstractString)
 end
 
 function setup_environment(typython_dir::AbstractString)
-    println("setup!")
-    flush(stdout)
     if !check_if_typython_installed(typython_dir)
         _develop_typython(typython_dir)
         Pkg.resolve()
@@ -38,7 +37,7 @@ end
 The precompiled file goes wrong for unknown reason.
 Removing and re-adding works.
 """
-function force_resolve(typython_dir::AbstractString)
+@noinline function force_resolve(typython_dir::AbstractString)
     try
         Pkg.rm("TyPython", io=devnull)
     catch
@@ -49,9 +48,9 @@ function force_resolve(typython_dir::AbstractString)
     nothing
 end
 
-function activate_project(project_dir::AbstractString, typython_dir::AbstractString; check::Bool=true)
+@noinline function activate_project(project_dir::AbstractString, typython_dir::AbstractString)
     Pkg.activate(project_dir, io=devnull)
-    check && force_resolve(typython_dir)
+    force_resolve(typython_dir)
     nothing
 end
 

--- a/jnumpy/apis.py
+++ b/jnumpy/apis.py
@@ -5,7 +5,6 @@ from jnumpy.init import JuliaError, exec_julia
 import contextlib
 import subprocess
 import pathlib
-import time
 
 
 def include_src(src_file: str, current_file_path: str = "./__init__.py"):
@@ -27,12 +26,10 @@ def include_src(src_file: str, current_file_path: str = "./__init__.py"):
 
 @contextlib.contextmanager
 def activate_project_nocheck(project_dir: str):
-    S0 = time.time()
     exec_julia(
         f"Pkg.activate({escape_to_julia_rawstr(project_dir)}, io=devnull)",
         use_gil=False,
     )
-    print(time.time() - S0)
     try:
         yield
     finally:

--- a/jnumpy/apis.py
+++ b/jnumpy/apis.py
@@ -35,7 +35,7 @@ def activate_project_nocheck(project_dir: str):
         yield
     finally:
         exec_julia(
-            f"Pkg.activate({escape_to_julia_rawstr(project_dir)}, io=devnull)",
+            f"Pkg.activate({escape_to_julia_rawstr(SessionCtx.DEFAULT_PROJECT_DIR)}, io=devnull)",
             use_gil=False,
         )
 

--- a/jnumpy/apis.py
+++ b/jnumpy/apis.py
@@ -5,6 +5,7 @@ from jnumpy.init import JuliaError, exec_julia
 import contextlib
 import subprocess
 import pathlib
+import tomli
 
 
 def include_src(src_file: str, current_file_path: str = "./__init__.py"):
@@ -58,22 +59,18 @@ def activate_project_checked(project_dir: str):
 
 def get_project_name_no_exc(project_dir: str):
     """!!!This function can return empty string!"""
+    project_path = pathlib.Path(project_dir).joinpath("Project.toml")
+
+    with open(project_path, "rb") as f:
+        toml_dict = tomli.load(f)
     try:
-        name = invoke_interpreted_julia(
-            SessionCtx.JULIA_EXE,
-            [
-                "-e",
-                rf'import TOML; TOML.parsefile(joinpath({escape_to_julia_rawstr(project_dir)}, "Project.toml"))["name"] |> println',
-            ],
-        )
-    except subprocess.CalledProcessError:
+        name = toml_dict["name"]
+    except KeyError:
         raise RuntimeError(
             f"{project_dir} does not have a Project.toml with a top-level"
             f"entry 'name = xxx' and the '[deps]' section."
         )
-    if isinstance(name, bytes):
-        jl_module_name = name.decode("utf-8").strip()
-        return jl_module_name
+    return name
 
 
 def get_project_name_checked(project_dir: str):

--- a/jnumpy/apis.py
+++ b/jnumpy/apis.py
@@ -5,6 +5,7 @@ from jnumpy.init import JuliaError, exec_julia
 import contextlib
 import subprocess
 import pathlib
+import time
 
 
 def include_src(src_file: str, current_file_path: str = "./__init__.py"):
@@ -26,17 +27,17 @@ def include_src(src_file: str, current_file_path: str = "./__init__.py"):
 
 @contextlib.contextmanager
 def activate_project_nocheck(project_dir: str):
+    S0 = time.time()
     exec_julia(
-        f"InitTools.activate_project({escape_to_julia_rawstr(project_dir)},"
-        f"{escape_to_julia_rawstr(TyPython_directory)}; check=false)",
+        f"Pkg.activate({escape_to_julia_rawstr(project_dir)}, io=devnull)",
         use_gil=False,
     )
+    print(time.time() - S0)
     try:
         yield
     finally:
         exec_julia(
-            f"InitTools.activate_project({escape_to_julia_rawstr(SessionCtx.DEFAULT_PROJECT_DIR)},"
-            f"{escape_to_julia_rawstr(TyPython_directory)}; check=false)",
+            f"Pkg.activate({escape_to_julia_rawstr(project_dir)}, io=devnull)",
             use_gil=False,
         )
 

--- a/jnumpy/tests/extension/src/extension.jl
+++ b/jnumpy/tests/extension/src/extension.jl
@@ -56,4 +56,6 @@ function init()
     end
 end
 
+precompile(init, ())
+
 end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ include = ["jnumpy/TyPython/Project.toml", "jnumpy/TyPython/src/*.jl"]
 [tool.poetry.dependencies]
 python = "^3.7"
 numpy = "^1.18"
+tomli = "^2.0.1"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
`Pkg.activate` is actually much faster than a simple wrapper of it. This reduces the loading time of a user Julia package from 2s to 0.4s (init julia requires 1s), if this is the first user package to load.

