### PR TITLE
[WIP] Support no-copy conversion of row major ndarray

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Note that JNumPy will install julia in `JNUMPY_HOME` for you, if there is no Jul
     using TyPython
     using TyPython.CPython
 
-    @export_py function mat_mul(a::AbstractArray, b::AbstractArray)::AbstractArray
+    @export_py function mat_mul(a::AbstractArray, b::AbstractArray)::Array
         return a * b
     end
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Note that JNumPy will install julia in `JNUMPY_HOME` for you, if there is no Jul
     using TyPython
     using TyPython.CPython
 
-    @export_py function mat_mul(a::StridedArray, b::StridedArray)::StridedArray
+    @export_py function mat_mul(a::AbstractArray, b::AbstractArray)::AbstractArray
         return a * b
     end
 

--- a/TyPython/src/CPython.Julia.jl
+++ b/TyPython/src/CPython.Julia.jl
@@ -70,7 +70,7 @@ function DynamicArray(x::TArray) where TArray<:AbstractArray
     elseif x isa PermutedDimsArray
         return permutedims(DynamicArray(parent(x)), get_perm(x))
     end
-    normalized_x = if x isa Array
+    normalized_x = if x isa StridedArray
         x
     else
         collect(x)

--- a/TyPython/src/CPython.Julia.jl
+++ b/TyPython/src/CPython.Julia.jl
@@ -137,7 +137,7 @@ function py_coerce(::Type{Py}, @nospecialize(xs::DynamicArray))
     np = get_numpy()
     nparray = np.asarray(types.SimpleNamespace(__array_struct__ = capsule))
     if xs.need_permute
-        nparray = nparray.transpose(py_cast(Py, Tuple(xs.perm)))
+        nparray = nparray.transpose(py_cast(Py, xs.perm))
     end
     return nparray
 end

--- a/TyPython/src/CPython.Julia.jl
+++ b/TyPython/src/CPython.Julia.jl
@@ -67,7 +67,7 @@ function DynamicArray(x::TArray) where TArray<:AbstractArray
     typekind = get_typekind(zero(et))
     if x isa LinearAlgebra.Transpose
         return LinearAlgebra.transpose(DynamicArray(LinearAlgebra.transpose(x)))
-    elseif x isa PermutedDimsArray
+    elseif x isa PermutedDimsArray && parent(x) isa StridedArray
         return permutedims(DynamicArray(parent(x)), get_perm(x))
     end
     normalized_x = if x isa StridedArray

--- a/TyPython/src/CPython.Julia.jl
+++ b/TyPython/src/CPython.Julia.jl
@@ -152,6 +152,11 @@ function py_coerce(::Type{Py}, @nospecialize(xs::DynamicArray))
     return nparray
 end
 
+"""
+    convert julia array to numpy ndarray
+Array, Transpose of Array, PermutedDimsArray of Array and some SubArray could be converted to ndarray without copy,
+other arrays will first be copied with collect(), then converted to ndarray.
+"""
 function py_coerce(::Type{Py}, @nospecialize(xs::AbstractArray))
     xs = DynamicArray(xs)
     py_coerce(Py, xs)

--- a/TyPython/src/CPython.NumPy.jl
+++ b/TyPython/src/CPython.NumPy.jl
@@ -1,5 +1,3 @@
-export get_numpy
-
 const Py_intptr_t = Cssize_t  # TODO: verify for portability
 
 const NPY_ARRAY_C_CONTIGUOUS = Cint(0x0001)
@@ -74,6 +72,13 @@ function _get_capsule_ptr(x::Py)
     return ptr
 end
 
+
+"""
+    convert numpy ndarray to julia array
+ndarray with F-contiguous could be converted to Array without copy,
+ndarray with C-contiguous could be converted to Transpose of Array(2D) or PermutedDimsArray of Array(high dimensions) without copy,
+other ndarray will first be copied to f-contiguous ndarray, then converted to Array.
+"""
 function from_ndarray(x::Py)
     np = get_numpy()
     if PyAPI.PyObject_HasAttr(x, attribute_symbol_to_pyobject(:__array_struct__)) != 1

--- a/TyPython/src/CPython.NumPy.jl
+++ b/TyPython/src/CPython.NumPy.jl
@@ -83,7 +83,6 @@ function from_ndarray(x::Py)
     ptr = C.Ptr{PyArrayInterface}(_get_capsule_ptr(__array_struct__))
     info = ptr[] :: PyArrayInterface
     info.typekind in supported_kinds || error("unsupported numpy dtype: $(Char(ptr.typekind))")
-    # TODO: support no-copy transpose in the future
     flags = info.flags
     if (!(checkbit(flags, NPY_ARRAY_F_CONTIGUOUS) || checkbit(flags, NPY_ARRAY_C_CONTIGUOUS)) ||
         !checkbit(flags, TYPY_SUPPORTED_NO_COPY_NP_FLAG))
@@ -152,7 +151,7 @@ function from_ndarray(x::Py)
         if info.nd == 2
             arr = transpose(arr)
         elseif info.nd > 2
-            perm = Tuple(Int(info.nd):-1:1) # todo: check nd>0
+            perm = Tuple(reverse(1:info.nd))
             arr = PermutedDimsArray(arr, perm)
         end
     end

--- a/TyPython/src/CPython.ORM.jl
+++ b/TyPython/src/CPython.ORM.jl
@@ -190,7 +190,7 @@ function py_coerce(::Type{T}, py::Py)::T where T <: AbstractString
     return convert(T, Base.unsafe_string(buf, size_ref[]))
 end
 
-function py_coerce(::Type{TArray}, py::Py)::TArray where {TArray <: StridedArray}
+function py_coerce(::Type{TArray}, py::Py)::TArray where {TArray <: AbstractArray}
     np = get_numpy()
     if PyAPI.PyObject_IsInstance(py, np.ndarray) == 0
         py_seterror!(G_PyBuiltin.TypeError, "expected numpy array")
@@ -353,7 +353,11 @@ function array_cast_trait(::Type{TArray}) where TArray<:StridedArray
     return SupportedArrayCast()
 end
 
-function array_cast_trait(::Type{LinearAlgebra.Transpose{S, TArray}}) where {S, TArray<:StridedArray{S}}
+function array_cast_trait(::Type{LinearAlgebra.Transpose{T, TArray}}) where {T, TArray<:StridedArray{T}}
+    return SupportedArrayCast()
+end
+
+function array_cast_trait(::Type{PermutedDimsArray{T, N, perm, iperm, AA}}) where {T, N, perm, iperm, AA<:StridedArray{T}}
     return SupportedArrayCast()
 end
 

--- a/TyPython/src/CPython.ORM.jl
+++ b/TyPython/src/CPython.ORM.jl
@@ -338,29 +338,5 @@ function py_cast(::Type{Py}, o::Py)
 end
 
 function py_cast(::Type{Py}, o::T) where T <: AbstractArray
-    py_cast_array(o, array_cast_trait(T))
-end
-
-struct SupportedArrayCast end
-struct UnsupportedArrayCast end
-
-
-function array_cast_trait(T)
-    return UnsupportedArrayCast()
-end
-
-function array_cast_trait(::Type{TArray}) where TArray<:StridedArray
-    return SupportedArrayCast()
-end
-
-function array_cast_trait(::Type{LinearAlgebra.Transpose{T, TArray}}) where {T, TArray<:StridedArray{T}}
-    return SupportedArrayCast()
-end
-
-function array_cast_trait(::Type{PermutedDimsArray{T, N, perm, iperm, AA}}) where {T, N, perm, iperm, AA<:StridedArray{T}}
-    return SupportedArrayCast()
-end
-
-function py_cast_array(o::T, ::SupportedArrayCast) where T<:AbstractArray
     py_coerce(Py, o)
 end

--- a/TyPython/src/CPython.ORM.jl
+++ b/TyPython/src/CPython.ORM.jl
@@ -292,7 +292,7 @@ end
     end
 end
 
-function py_cast(::Type{TArray}, py::Py)::TArray where {TArray <: StridedArray}
+function py_cast(::Type{TArray}, py::Py)::TArray where {TArray <: AbstractArray}
     py_coerce(TArray, py)
 end
 

--- a/TyPython/src/CPython.jl
+++ b/TyPython/src/CPython.jl
@@ -3,7 +3,7 @@ using MLStyle: @match, @switch
 import LinearAlgebra
 import TyPython.C
 import TyPython.Utils: capture_out, unroll_do!
-export get_py_builtin, py_throw, WITH_GIL, GILNoRaise
+export get_numpy, get_py_builtin, py_throw, WITH_GIL, GILNoRaise
 export py_cast, py_coerce
 export Py
 

--- a/TyPython/test/convert.jl
+++ b/TyPython/test/convert.jl
@@ -146,9 +146,24 @@ end
         @test !(py_cast(Bool, py_b.flags.f_contiguous))
         @test py_cast(NTuple{3, Int}, py_b.shape) == (4, 3, 2)
         @test py_cast(PermutedDimsArray, py_b) == b
+        b[1] = 0
+        @test py_cast(Int64, py_b.__getitem__(py_cast(Py, (0,0,0)))) == 0
         np = CPython.get_numpy()
         py_c = np.random.random(py_cast(Py, (2, 3, 4))).transpose(py_cast(Py, (2, 0, 1)))
         @test py_cast(Array, py_c) isa Array{Float64, 3}
+    end
+    @testset "Array with shpae (1,k,1,1)" begin
+        d = rand(1, 10, 1, 1)
+        py_d = py_cast(Py, d)
+        @test py_cast(Bool, py_d.flags.c_contiguous)
+        @test py_cast(Bool, py_d.flags.f_contiguous)
+        d[1] = 0.0
+        @test py_cast(Float64, py_d.__getitem__(py_cast(Py, (0,0,0,0)))) == 0.0
+        py_dT = py_cast(Py, PermutedDimsArray(d, (4, 3, 1, 2)))
+        @test py_cast(Bool, py_dT.flags.c_contiguous)
+        @test py_cast(Bool, py_dT.flags.f_contiguous)
+        d[2] = 1.0
+        @test py_cast(Float64, py_dT.__getitem__(py_cast(Py, (0,0,0,1)))) == 1.0
     end
     @test_throws CPython.PyException py_cast(Array, py_cast(Py, "abc"))
 end

--- a/TyPython/test/convert.jl
+++ b/TyPython/test/convert.jl
@@ -49,7 +49,7 @@ end
     @test isnothing(py_coerce(Nothing, py_cast(Py, nothing)))
 
     @test py_coerce(Bool, py_cast(Py, true))
-    @test !py_coerce(Bool, py_cast(Py, false))
+    @test !(py_coerce(Bool, py_cast(Py, false)))
     @test_throws CPython.PyException py_coerce(Bool, py_cast(Py, 1))
 
     @test py_coerce(Int, py_cast(Py, 1)) == 1
@@ -83,7 +83,7 @@ end
     @test_throws CPython.PyException py_cast(Nothing, py_cast(Py, "abc"))
 
     @test py_cast(Bool, py_cast(Py, true))
-    @test !py_cast(Bool, py_cast(Py, false))
+    @test !(py_cast(Bool, py_cast(Py, false)))
     @test py_cast(Bool, py_cast(Py, 1))
 
     @test py_cast(Int, py_cast(Py, 1)) == 1
@@ -110,19 +110,46 @@ end
     # in these cases py_cast falls back to py_coerce
     @test py_cast(String, py_cast(Py, "äbc")) == "äbc"
     a = [1 2 3; 3 4 5]
-    @test py_cast(Array, py_cast(Py, a)) == a
-    @test py_cast(Array, py_cast(Py, transpose(a))) == collect(transpose(a))
-    @test py_cast(Array, py_cast(Py, a')) == collect(transpose(a))
-    x4 = py_cast(Matrix{Int32}, py_cast(Py, a))
-    @test x4 isa Matrix{Int32}
-    @test x4 == Int32.(a)
-    b = PermutedDimsArray(rand(Int, (2, 3, 4)), (3, 2, 1))
-    c = py_cast(Py, b)
-    @test py_cast(NTuple{3, Int}, c.shape) == (4, 3, 2)
-    @test py_cast(PermutedDimsArray, c) == b
-    np = CPython.get_numpy()
-    d = np.random.random(py_cast(Py, (2, 3, 4))).transpose(py_cast(Py, (2, 0, 1)))
-    @test py_cast(Array, d) isa Array{Float64, 3}
+    @testset "Array -> ndarray" begin
+        py_a = py_cast(Py, a)
+        @test py_cast(Array, py_a) == a
+        @test py_cast(Bool, py_a.flags.f_contiguous)
+        @test !(py_cast(Bool, py_a.flags.c_contiguous))
+        x = py_cast(Matrix{Int32}, py_a)
+        @test x isa Matrix{Int32}
+        @test x == Int32.(a)
+    end
+    @testset "SubArray -> ndarray" begin
+        a1 = @views a[1:1, 1:3] # not f contiguous
+        py_a1 = py_cast(Py, a1)
+        @test py_cast(Array, py_a1) == a1
+        @test !(py_cast(Bool, py_a1.flags.f_contiguous))
+        @test !(py_cast(Bool, py_a1.flags.c_contiguous))
+        a2 = @views a[1:2, 1:2] # f contiguous
+        py_a2 = py_cast(Py, a2)
+        @test py_cast(Array, py_a2) == a2
+        @test py_cast(Bool, py_a2.flags.f_contiguous)
+        @test !(py_cast(Bool, py_a2.flags.c_contiguous))
+    end
+    @testset "Transpose -> ndarray" begin
+        py_aT = py_cast(Py, transpose(a))
+        @test py_cast(Array, py_aT) == collect(transpose(a))
+        @test py_cast(Bool, py_aT.flags.c_contiguous)
+        @test !(py_cast(Bool, py_aT.flags.f_contiguous))
+        @test py_cast(Array, py_cast(Py, a')) == collect(a')
+        @test py_cast(Bool, py_cast(Py, a').flags.f_contiguous) # copy
+    end
+    @testset "PermutedDimsArray -> ndarray" begin
+        b = PermutedDimsArray(rand(Int, (2, 3, 4)), (3, 2, 1))
+        py_b = py_cast(Py, b)
+        @test py_cast(Bool, py_b.flags.c_contiguous)
+        @test !(py_cast(Bool, py_b.flags.f_contiguous))
+        @test py_cast(NTuple{3, Int}, py_b.shape) == (4, 3, 2)
+        @test py_cast(PermutedDimsArray, py_b) == b
+        np = CPython.get_numpy()
+        py_c = np.random.random(py_cast(Py, (2, 3, 4))).transpose(py_cast(Py, (2, 0, 1)))
+        @test py_cast(Array, py_c) isa Array{Float64, 3}
+    end
     @test_throws CPython.PyException py_cast(Array, py_cast(Py, "abc"))
 end
 

--- a/TyPython/test/convert.jl
+++ b/TyPython/test/convert.jl
@@ -112,6 +112,7 @@ end
     a = [1 2 3; 3 4 5]
     @test py_cast(Array, py_cast(Py, a)) == a
     @test py_cast(Array, py_cast(Py, transpose(a))) == collect(transpose(a))
+    @test py_cast(Array, py_cast(Py, a')) == collect(transpose(a))
     x4 = py_cast(Matrix{Int32}, py_cast(Py, a))
     @test x4 isa Matrix{Int32}
     @test x4 == Int32.(a)
@@ -120,7 +121,6 @@ end
     @test py_cast(NTuple{3, Int}, c.shape) == (4, 3, 2)
     @test py_cast(PermutedDimsArray, c) == b
     @test_throws CPython.PyException py_cast(Array, py_cast(Py, "abc"))
-    @test_throws MethodError py_cast(Py, a') # adjoint is unspported
 end
 
 @testset "kwargs" begin

--- a/TyPython/test/convert.jl
+++ b/TyPython/test/convert.jl
@@ -120,6 +120,9 @@ end
     c = py_cast(Py, b)
     @test py_cast(NTuple{3, Int}, c.shape) == (4, 3, 2)
     @test py_cast(PermutedDimsArray, c) == b
+    np = CPython.get_numpy()
+    d = np.random.random(py_cast(Py, (2, 3, 4))).transpose(py_cast(Py, (2, 0, 1)))
+    @test py_cast(Array, d) isa Array{Float64, 3}
     @test_throws CPython.PyException py_cast(Array, py_cast(Py, "abc"))
 end
 

--- a/TyPython/test/convert.jl
+++ b/TyPython/test/convert.jl
@@ -110,11 +110,15 @@ end
     # in these cases py_cast falls back to py_coerce
     @test py_cast(String, py_cast(Py, "äbc")) == "äbc"
     a = [1 2 3; 3 4 5]
-    @test py_cast(Array, py_cast(Py, a)) == [1 2 3; 3 4 5]
-    @test py_cast(Array, py_cast(Py, transpose(a))) == [1 3; 2 4; 3 5]
-    x4 = py_cast(Matrix{Int32}, py_cast(Py, Float32.(a)))
+    @test py_cast(Array, py_cast(Py, a)) == a
+    @test py_cast(Array, py_cast(Py, transpose(a))) == collect(transpose(a))
+    x4 = py_cast(Matrix{Int32}, py_cast(Py, a))
     @test x4 isa Matrix{Int32}
-    @test x4 == Int32[1 2 3; 3 4 5]
+    @test x4 == Int32.(a)
+    b = PermutedDimsArray(rand(Int, (2, 3, 4)), (3, 2, 1))
+    c = py_cast(Py, b)
+    @test py_cast(NTuple{3, Int}, c.shape) == (4, 3, 2)
+    @test py_cast(PermutedDimsArray, c) == b
     @test_throws CPython.PyException py_cast(Array, py_cast(Py, "abc"))
     @test_throws MethodError py_cast(Py, a') # adjoint is unspported
 end

--- a/TyPython/test/pyexport.jl
+++ b/TyPython/test/pyexport.jl
@@ -28,11 +28,11 @@ end
     return a, b
 end
 
-@export_py function mat_mul(a::StridedArray, b::StridedArray)::StridedArray
+@export_py function mat_mul(a::AbstractArray, b::AbstractArray)::AbstractArray
     return a * b
 end
 
-@export_py function set_zero(a::StridedArray)::Nothing
+@export_py function set_zero(a::AbstractArray)::Nothing
     a[1] = zero(eltype(a))
     return nothing
 end

--- a/TyPython/test/pyexport.jl
+++ b/TyPython/test/pyexport.jl
@@ -28,7 +28,7 @@ end
     return a, b
 end
 
-@export_py function mat_mul(a::AbstractArray, b::AbstractArray)::AbstractArray
+@export_py function mat_mul(a::AbstractArray, b::AbstractArray)::Array
     return a * b
 end
 

--- a/demo/basic/src/basic.jl
+++ b/demo/basic/src/basic.jl
@@ -7,7 +7,7 @@ using TyPython.CPython
     return a + b
 end
 
-@export_py function mat_mul(a::AbstractArray, b::AbstractArray)::AbstractArray
+@export_py function mat_mul(a::AbstractArray, b::AbstractArray)::Array
     return a * b
 end
 

--- a/demo/basic/src/basic.jl
+++ b/demo/basic/src/basic.jl
@@ -7,7 +7,7 @@ using TyPython.CPython
     return a + b
 end
 
-@export_py function mat_mul(a::StridedArray, b::StridedArray)::StridedArray
+@export_py function mat_mul(a::AbstractArray, b::AbstractArray)::AbstractArray
     return a * b
 end
 

--- a/demo/fft/src/fast_fft.jl
+++ b/demo/fft/src/fast_fft.jl
@@ -12,7 +12,7 @@ const plan1Ds = Dict{Tuple{DataType, NTuple{N, Int} where N}, FFT1D_PlanType}()
 """
 1-D FFT
 """
-@export_py function jl_fft(x::StridedVector)::StridedVector{ComplexF64}
+@export_py function jl_fft(x::StridedVector)::Vector{ComplexF64}
     x = collect(ComplexF64, x)
     plan = get!(plan1Ds, (typeof(x), size(x))) do
         FFTW.plan_fft(copy(x), 1; flags=FFTW.MEASURE)

--- a/demo/kmeans/src/fast_kmeans.jl
+++ b/demo/kmeans/src/fast_kmeans.jl
@@ -5,7 +5,7 @@ using TyPython.CPython
 using MKL
 import ParallelKMeans
 
-@export_py function _fast_kmeans(x::StridedArray, n::Int)::Tuple{StridedArray, StridedArray}
+@export_py function _fast_kmeans(x::StridedArray, n::Int)::Tuple{Array, Array}
     r = ParallelKMeans.kmeans(ParallelKMeans.Hamerly(), x, n)
     return (r.assignments, r.centers)
 end

--- a/jnumpy/tests/extension/src/extension.jl
+++ b/jnumpy/tests/extension/src/extension.jl
@@ -28,7 +28,7 @@ end
     return a, b
 end
 
-@export_py function mat_mul(a::StridedArray, b::StridedArray)::StridedArray
+@export_py function mat_mul(a::AbstractArray, b::AbstractArray)::AbstractArray
     return a * b
 end
 

--- a/jnumpy/tests/extension/src/extension.jl
+++ b/jnumpy/tests/extension/src/extension.jl
@@ -28,7 +28,7 @@ end
     return a, b
 end
 
-@export_py function mat_mul(a::AbstractArray, b::AbstractArray)::AbstractArray
+@export_py function mat_mul(a::AbstractArray, b::AbstractArray)::Array
     return a * b
 end
 


### PR DESCRIPTION
Here is the rule of conversion of ndarray:

- x is a `numpy.ndarray`

  + if x is col-major(Fortran order in memory), `from_ndarray(x)` returns an `Array` in julia with same shape.
  + if x is row-major(C order in memory), `from_ndarray(x)` returns a `Transpose` or `PermutedDimsArray` in julia with same shape.
  + `py_coerce(T, x)` will first convert x with `conver(T, from_ndarray(x))`, if `T` is `Array` but `from_ndarray(x)` returns a `Transpose` or `PermutedDimsArray`, we still need to copy data into a new Array.
    
- y is a julia's `StridedArray`(or `Transpose`\\`PermutedDimsArray` ) 

  + if y is a `StridedArray`, `py_cast(Py, y)` returns a col-major `ndarray`.
  + if y is a `Transpose`, `py_cast(Py, y)` returns a row-major `ndarray`.
  + if y is a `PermutedDimsArray`, `py_cast(Py, y)` first converts `y.parent` to `ndarray` then transposes it with same permutation.
