### PR TITLE
Check f-contiguous when ndarray have shape like (1, k, 1, 1)

### DIFF
--- a/TyPython/src/CPython.NumPy.jl
+++ b/TyPython/src/CPython.NumPy.jl
@@ -101,7 +101,7 @@ function from_ndarray(x::Py)
     shape = Tuple(Int(i)
         for i in unsafe_wrap(Array, convert(Ptr{Py_intptr_t}, info.shape), Int(info.nd); own=false)) :: ShapeType
 
-    if checkbit(flags, NPY_ARRAY_C_CONTIGUOUS)
+    if checkbit(flags, NPY_ARRAY_C_CONTIGUOUS) && !(checkbit(flags, NPY_ARRAY_F_CONTIGUOUS))
         shape = reverse(shape)
     end
 
@@ -152,7 +152,7 @@ function from_ndarray(x::Py)
             throw(error("unsupported numpy dtype: $(code) $(nbytes)"))
     end
 
-    if checkbit(flags, NPY_ARRAY_C_CONTIGUOUS)
+    if checkbit(flags, NPY_ARRAY_C_CONTIGUOUS) && !(checkbit(flags, NPY_ARRAY_F_CONTIGUOUS))
         if info.nd == 2
             arr = transpose(arr)
         elseif info.nd > 2

--- a/TyPython/test/convert.jl
+++ b/TyPython/test/convert.jl
@@ -109,6 +109,7 @@ end
 
     # in these cases py_cast falls back to py_coerce
     @test py_cast(String, py_cast(Py, "äbc")) == "äbc"
+    np = CPython.get_numpy()
     a = [1 2 3; 3 4 5]
     @testset "Array -> ndarray" begin
         py_a = py_cast(Py, a)
@@ -148,7 +149,6 @@ end
         @test py_cast(PermutedDimsArray, py_b) == b
         b[1] = 0
         @test py_cast(Int64, py_b.__getitem__(py_cast(Py, (0,0,0)))) == 0
-        np = CPython.get_numpy()
         py_c = np.random.random(py_cast(Py, (2, 3, 4))).transpose(py_cast(Py, (2, 0, 1)))
         @test py_cast(Array, py_c) isa Array{Float64, 3}
     end
@@ -164,6 +164,8 @@ end
         @test py_cast(Bool, py_dT.flags.f_contiguous)
         d[2] = 1.0
         @test py_cast(Float64, py_dT.__getitem__(py_cast(Py, (0,0,0,1)))) == 1.0
+        e = np.random.random(py_cast(Py, (1, 10, 1, 1)))
+        @test py_cast(AbstractArray, e) isa Array
     end
     @test_throws CPython.PyException py_cast(Array, py_cast(Py, "abc"))
 end


### PR DESCRIPTION
If ndarray is f-contiguous, it should be converted to Array. So, check it when it's both f-contiguous and c-contiguous

```julia
  julia> a = np.random.random(py_cast(Py, (1,3,1,1)))
  julia> py_coerce(AbstractArray, a)
  1×3×1×1 Array{Float64, 4}:
  ...
```