### PR TITLE
search fast julia pkg server

### DIFF
--- a/jnumpy/utils.py
+++ b/jnumpy/utils.py
@@ -4,15 +4,72 @@ import io
 import json
 import subprocess
 import contextlib
+import time
+import http.client
+import threading
 
 
 def set_julia_path(path: str):
     path = os.path.abspath(os.path.expanduser(path))
     os.environ["TYPY_JL_EXE"] = path
 
+# only work when users haven't set the environment `JULIA_PKG_SERVER` manually
+def set_julia_mirror(server: str=""):
+    if not os.environ.get("JULIA_PKG_SERVER"):
+        server = server if server else get_fast_mirror()
+        os.environ["JULIA_PKG_SERVER"] = server
 
-def set_julia_mirror(upstream: str):
-    os.environ["JILL_UPSTREAM"] = upstream
+# python version of https://github.com/johnnychen94/PkgServerClient.jl/blob/master/src/PkgServerClient.jl
+def get_fast_mirror():
+    response_time = registry_response_time()
+    fast_mirror = sorted(response_time.items(), key=lambda x: x[1])[0][0]
+    # When all fails to response in a very limited `timeout` time, set the default to "JuliaLang"
+    if response_time[fast_mirror] >= 1000:
+        url = "https://pkg.julialang.org"
+    else:
+        url = f"https://{fast_mirror}/julia"
+    return url
+
+def registry_response_time(timeout: float=1.0):
+    timeout = max(0.001, timeout) # The minimal is 1ms, otherwise it is likely to be ignored.
+
+    hosts = ["mirrors.bfsu.edu.cn",
+            "mirror.iscas.ac.cn",
+            "mirrors.nju.edu.cn",
+            "opentuna.cn",
+            "mirrors.sjtug.sjtu.edu.cn",
+            "mirrors.sustech.edu.cn",
+            "mirrors.tuna.tsinghua.edu.cn",
+            "mirrors.ustc.edu.cn"]
+    num_threads = len(hosts)
+    _registry_response_time = {key:float('inf') for key in hosts}
+
+    def response_time(conn: http.client.HTTPSConnection, host: str):
+        start = time.time()
+        try:
+            conn.request("HEAD","/julia/registries")
+            conn.getresponse()
+            _registry_response_time[host] = time.time() - start
+        except:
+            _registry_response_time[host] = float('inf')
+    def wait_thread(host: str, timeout: float):
+        conn = http.client.HTTPSConnection(host)
+        worker = threading.Thread(target=response_time, args=(conn, host))
+        worker.start()
+        worker.join(timeout)
+        conn.close()
+
+    workers = []
+    for i in range(num_threads):
+        worker = threading.Thread(target=wait_thread, args=(hosts[i], timeout))
+        worker.setDaemon(True)
+        worker.start()
+        workers.append(worker)
+
+    for worker in workers:
+        worker.join()
+
+    return _registry_response_time
 
 
 def escape_string(s: str):


### PR DESCRIPTION
Implement https://github.com/johnnychen94/PkgServerClient.jl in python
Works like:

```
In [1]: import jnumpy as np

In [2]: %time np.utils.registry_response_time()
CPU times: user 93.9 ms, sys: 20.9 ms, total: 115 ms
Wall time: 1.06 s
Out[2]: 
{'mirrors.bfsu.edu.cn': 0.385467529296875,
 'mirror.iscas.ac.cn': 0.7986209392547607,
 'mirrors.nju.edu.cn': 0.6467490196228027,
 'opentuna.cn': 0.4409325122833252,
 'mirrors.sjtug.sjtu.edu.cn': 0.3874180316925049,
 'mirrors.sustech.edu.cn': 0.6435022354125977,
 'mirrors.tuna.tsinghua.edu.cn': inf,
 'mirrors.ustc.edu.cn': 0.3986549377441406}

In [3]: %time np.utils.get_fast_mirror()
CPU times: user 86.6 ms, sys: 16.7 ms, total: 103 ms
Wall time: 1.07 s
Out[3]: 'https://mirrors.ustc.edu.cn/julia'
```

And `set_julia_mirror(server)` can set custom server url manually, or leave it empty to auto search fast server with `get_fast_mirror()`