### PR TITLE
Support bool array

### DIFF
--- a/TyPython/src/CPython.Julia.jl
+++ b/TyPython/src/CPython.Julia.jl
@@ -51,6 +51,10 @@ function get_perm(x::PermutedDimsArray{T, N, perm}) where {T, N, perm}
     return perm .- 1
 end
 
+function get_typekind(_::Bool)
+    return Cchar('b')
+end
+
 function get_typekind(_::Union{Int8, Int16, Int32, Int64})
     return Cchar('i')
 end

--- a/TyPython/src/CPython.NumPy.jl
+++ b/TyPython/src/CPython.NumPy.jl
@@ -42,7 +42,7 @@ function get_numpy()
     return G_numpy
 end
 
-const supported_kinds = Cchar['i', 'u', 'f', 'c']
+const supported_kinds = Cchar['b', 'i', 'u', 'f', 'c']
 
 const SupportedNDim = 32  # hard coded in numpy
 const ShapeType = Union{(Tuple{repeat([Py_intptr_t], i)...} for i = 0:SupportedNDim)...}
@@ -108,6 +108,9 @@ function from_ndarray(x::Py)
     end
 
     arr = @switch (Char(info.typekind), Int(info.itemsize)) begin
+        @case ('b', 1)
+            register_root(x,
+                unsafe_wrap(Array, convert(Ptr{Bool}, info.data), shape; own=false))
         @case ('i', 1)
             register_root(x,
                 unsafe_wrap(Array, convert(Ptr{Int8}, info.data), shape; own=false))

--- a/TyPython/test/convert.jl
+++ b/TyPython/test/convert.jl
@@ -167,6 +167,11 @@ end
         e = np.random.random(py_cast(Py, (1, 10, 1, 1)))
         @test py_cast(AbstractArray, e) isa Array
     end
+    @testset "bool array" begin
+        f = rand(Bool, 2, 2)
+        py_f = py_cast(Py, f)
+        @test py_f.dtype == np.dtype(py_cast(Py, "bool"))
+    end
     @test_throws CPython.PyException py_cast(Array, py_cast(Py, "abc"))
 end
 

--- a/jnumpy/tests/test_core.py
+++ b/jnumpy/tests/test_core.py
@@ -57,8 +57,15 @@ def test_mat_mul(dtype):
     y = np.asarray([[7.8, 5e-3], [6.75, 8.234]], dtype=dtype)
     actual = mat_mul(x, y)
     desired = x @ y
+    assert actual.dtype == desired.dtype
     np.testing.assert_array_almost_equal(actual, desired, decimal=5)
 
+def test_bool_array():
+    x = np.asarray([[True, False], [True, False]])
+    x_int = x.astype('i')
+    actual = mat_mul(x, x)
+    desired = x_int @ x_int
+    assert np.all(actual == desired)
 
 def test_set_zero():
     x = np.random.rand(2)


### PR DESCRIPTION
support #46 

convert `ndarray` with dtype `'bool'` to julia's Array with element type `Bool`.

ps: julia's matrix multiplication of `Matrix{Bool}` acts differently from numpy:
```
julia> a = Bool[1 1; 1 0]
2×2 Matrix{Bool}:
 1  1
 1  0

julia> a * a
2×2 Matrix{Int64}:
 2  1
 1  1
```
while:

```
a = np.array([[True, True],[True, False]])
np.matmul(a, a)
# array([[ True,  True],
#       [ True,  True]])
```
