### PR TITLE
Support no-copy casting of `Base.ReinterpretArray`

### DIFF
--- a/TyPython/src/CPython.Julia.jl
+++ b/TyPython/src/CPython.Julia.jl
@@ -67,8 +67,8 @@ function get_typekind(_::Union{ComplexF16, ComplexF32, ComplexF64})
     return Cchar('c')
 end
 
-function DynamicArray(x::TArray) where TArray<:AbstractArray
-    et = eltype(TArray)
+function DynamicArray(x::AbstractArray)
+    et = eltype(x)
     typekind = get_typekind(zero(et))
     if x isa LinearAlgebra.Transpose && parent(x) isa StridedArray
         return LinearAlgebra.transpose(DynamicArray(LinearAlgebra.transpose(x)))
@@ -81,6 +81,8 @@ function DynamicArray(x::TArray) where TArray<:AbstractArray
         x
     elseif x isa StridedArray && x isa SubArray
         is_f_style = Base.iscontiguous(x)
+        x
+    elseif x isa StridedArray && x isa Base.ReinterpretArray && parent(x) isa Array
         x
     else
         collect(x)

--- a/TyPython/src/CPython.Julia.jl
+++ b/TyPython/src/CPython.Julia.jl
@@ -158,7 +158,7 @@ end
     py_coerce(::Type{Py}, xs::AbstractArray)
 
 Convert julia array to numpy ndarray.
-Array, Transpose of Array, PermutedDimsArray of Array and some SubArray could be converted to ndarray without copy,
+Array, Transpose of Array, PermutedDimsArray of Array and some SubArray/ReinterpretArray could be converted to ndarray without copy,
 other arrays will first be copied with `collect()`, then converted to ndarray.
 """
 function py_coerce(::Type{Py}, @nospecialize(xs::AbstractArray))

--- a/TyPython/src/CPython.ORM.jl
+++ b/TyPython/src/CPython.ORM.jl
@@ -340,6 +340,6 @@ function py_cast(::Type{Py}, o::Py)
     return o
 end
 
-function py_cast(::Type{Py}, o::T) where T <: AbstractArray
+function py_cast(::Type{Py}, o::T) where {T <: AbstractArray{<:Number}}
     py_coerce(Py, o)
 end

--- a/TyPython/test/convert.jl
+++ b/TyPython/test/convert.jl
@@ -167,6 +167,19 @@ end
         e = np.random.random(py_cast(Py, (1, 10, 1, 1)))
         @test py_cast(AbstractArray, e) isa Array
     end
+    @testset "SubArray and ReinterpretArray" begin
+        x = rand(4, 4)
+        x_sub = @view x[2:4, :]
+        py_x_sub = py_cast(Py, x_sub)
+        @test py_cast(Tuple{Int, Int}, py_x_sub.shape) == (3, 4)
+        @test py_cast(Float64, py_x_sub[py_cast(Py, (0,0))]) == x_sub[1, 1]
+        @test !py_cast(Bool, py_x_sub.flags.c_contiguous)
+        @test !py_cast(Bool, py_x_sub.flags.f_contiguous)
+        x_re = reinterpret(ComplexF64, x)
+        py_x_re = py_cast(Py, x_re)
+        @test py_cast(Tuple{Int, Int}, py_x_re.shape) == (2, 4)
+        @test pointer(py_cast(Array, py_x_re)) == pointer(x)
+    end
     @test_throws CPython.PyException py_cast(Array, py_cast(Py, "abc"))
 end
 


### PR DESCRIPTION
#49 and #50 