### PR TITLE
Improve error message

### DIFF
--- a/jnumpy/InitTools.jl
+++ b/jnumpy/InitTools.jl
@@ -4,6 +4,8 @@ import UUIDs
 
 @nospecialize
 
+const Error_Logger = IOBuffer()
+
 function check_if_typython_installed(typython_dir::AbstractString)
     VERSION >= v"1.9" && error("Support for Julia 1.9 is coming soon.")
     VERSION < v"1.6" && error("TyPython works for Julia >= 1.6!")
@@ -23,11 +25,16 @@ function _develop_typython(typython_dir::AbstractString)
     nothing
 end
 
-function setup_environment(typython_dir::AbstractString)
-    if !check_if_typython_installed(typython_dir)
-        _develop_typython(typython_dir)
-        Pkg.resolve()
-        Pkg.instantiate()
+function setup_environment(typython_dir::AbstractString; log_error::Bool=false)
+    try
+        if !check_if_typython_installed(typython_dir)
+            _develop_typython(typython_dir)
+            Pkg.resolve()
+            Pkg.instantiate()
+        end
+    catch e
+        log_error && Base.showerror(Error_Logger, e, catch_backtrace())
+        rethrow(e)
     end
     nothing
 end
@@ -37,20 +44,31 @@ end
 The precompiled file goes wrong for unknown reason.
 Removing and re-adding works.
 """
-@noinline function force_resolve(typython_dir::AbstractString)
+@noinline function force_resolve(typython_dir::AbstractString; log_error::Bool=false)
     try
         Pkg.rm("TyPython", io=devnull)
     catch
     end
-    Pkg.develop(path=typython_dir, io=devnull)
-    Pkg.resolve()
-    Pkg.instantiate()
+
+    try
+        Pkg.develop(path=typython_dir, io=devnull)
+        Pkg.resolve()
+        Pkg.instantiate()
+    catch e
+        log_error && Base.showerror(Error_Logger, e, catch_backtrace())
+        rethrow(e)
+    end
     nothing
 end
 
-@noinline function activate_project(project_dir::AbstractString, typython_dir::AbstractString)
+@noinline function activate_project(project_dir::AbstractString, typython_dir::AbstractString; log_error::Bool=false)
     Pkg.activate(project_dir, io=devnull)
-    force_resolve(typython_dir)
+    force_resolve(typython_dir, log_error=log_error)
+    nothing
+end
+
+function show_error_log()
+    println(stderr, String(take!(Error_Logger)))
     nothing
 end
 

--- a/jnumpy/apis.py
+++ b/jnumpy/apis.py
@@ -44,7 +44,7 @@ def activate_project_checked(project_dir: str):
     exec_julia(
         f"InitTools.activate_project({escape_to_julia_rawstr(project_dir)},"
         f"{escape_to_julia_rawstr(TyPython_directory)})",
-        use_gil=False,
+        use_gil=True,
     )
     try:
         yield
@@ -52,7 +52,7 @@ def activate_project_checked(project_dir: str):
         exec_julia(
             f"InitTools.activate_project({escape_to_julia_rawstr(SessionCtx.DEFAULT_PROJECT_DIR)},"
             f"{escape_to_julia_rawstr(TyPython_directory)})",
-            use_gil=False,
+            use_gil=True,
         )
 
 

--- a/jnumpy/init.py
+++ b/jnumpy/init.py
@@ -206,10 +206,19 @@ def init_jl(experimental_fast_init=False):
                 )
             except JuliaError:
                 pass
-            exec_julia(
-                f"InitTools.force_resolve({escape_to_julia_rawstr(TyPython_directory)})",
-                use_gil=False,
-            )
+            try:
+                # log julia's error in a IOBuffer, because we can't redirect error to python in this step
+                exec_julia(
+                    f"InitTools.force_resolve({escape_to_julia_rawstr(TyPython_directory)}, log_error=true)",
+                    use_gil=False,
+                )
+            except JuliaError:
+                # show error message in IOBuffer
+                exec_julia(
+                    "InitTools.show_error_log()",
+                    use_gil=False,
+                )
+                raise JuliaError("failed to setup julia environment, check the julia error message above.")
         try:
             exec_julia(
                 rf"""


### PR DESCRIPTION
Relate issue: #71 

 we can't redirect julia error before we call `init_jl()` succeeded, a simple solution is to log error message and print it in julia, like:

```
In [2]: np.init_jl()
   Resolving package versions...
SystemError: opening file "/home/songjhaha/github/jnumpy-repo/jnumpy/JNumPyEnv/Manifest.toml": Permission denied
Stacktrace:
  [1] systemerror(p::String, errno::Int32; extrainfo::Nothing)
    @ Base ./error.jl:174
  [2] #systemerror#68
    @ ./error.jl:173 [inlined]
...
---------------------------------------------------------------------------
JuliaError                                Traceback (most recent call last)
~/github/jnumpy-repo/jnumpy/init.py in init_jl(experimental_fast_init)
    199         try:
--> 200             exec_julia("import TyPython", use_gil=False)
    201         except JuliaError:
...

During handling of the above exception, another exception occurred:

JuliaError                                Traceback (most recent call last)
<ipython-input-2-922bdac64e73> in <module>
----> 1 np.init_jl()

~/github/jnumpy-repo/jnumpy/init.py in init_jl(experimental_fast_init)
    219                     use_gil=False,
    220                 )
--> 221                 raise JuliaError("failed to setup julia environment, check the julia error message above.")
    222         try:
    223             exec_julia(

JuliaError: failed to setup julia environment, check the julia error message above.
```


I think pyjulia(PyCall) have considered this situation: https://github.com/JuliaPy/pyjulia/blob/56a739126d3fed0d24e548069ff216fea78fbe1b/src/julia/core.py#L587

@thautwarm 